### PR TITLE
Fix `Vararg` warnings

### DIFF
--- a/src/combinators/power.jl
+++ b/src/combinators/power.jl
@@ -29,7 +29,7 @@ end
 
 # ToDo: Make rand return static arrays for statically-sized power measures.
 
-function _cartidxs(axs::Tuple{Vararg{<:AbstractUnitRange,N}}) where {N}
+function _cartidxs(axs::Tuple{Vararg{AbstractUnitRange,N}}) where {N}
     CartesianIndices(map(_dynamic, axs))
 end
 
@@ -49,16 +49,16 @@ function Base.rand(rng::AbstractRNG, ::Type{T}, d::PowerMeasure) where {T}
     end
 end
 
-@inline _pm_axes(sz::Tuple{Vararg{<:IntegerLike,N}}) where {N} = map(one_to, sz)
-@inline _pm_axes(axs::Tuple{Vararg{<:AbstractUnitRange,N}}) where {N} = axs
+@inline _pm_axes(sz::Tuple{Vararg{IntegerLike,N}}) where {N} = map(one_to, sz)
+@inline _pm_axes(axs::Tuple{Vararg{AbstractUnitRange,N}}) where {N} = axs
 
-@inline function powermeasure(x::T, sz::Tuple{Vararg{<:Any,N}}) where {T,N}
+@inline function powermeasure(x::T, sz::Tuple{Vararg{Any,N}}) where {T,N}
     PowerMeasure(x, _pm_axes(sz))
 end
 
 marginals(d::PowerMeasure) = fill_with(d.parent, d.axes)
 
-function Base.:^(μ::AbstractMeasure, dims::Tuple{Vararg{<:AbstractArray,N}}) where {N}
+function Base.:^(μ::AbstractMeasure, dims::Tuple{Vararg{AbstractArray,N}}) where {N}
     powermeasure(μ, dims)
 end
 

--- a/src/combinators/smart-constructors.jl
+++ b/src/combinators/smart-constructors.jl
@@ -11,7 +11,7 @@ powermeasure(m::AbstractMeasure, ::Tuple{}) = m
 
 function powermeasure(
     μ::WeightedMeasure,
-    dims::Tuple{<:AbstractArray,Vararg{<:AbstractArray}},
+    dims::Tuple{<:AbstractArray,Vararg{AbstractArray}},
 )
     k = mapreduce(length, *, dims) * μ.logweight
     return weightedmeasure(k, μ.base^dims)

--- a/src/static.jl
+++ b/src/static.jl
@@ -29,11 +29,11 @@ Returns an instance of `FillArrays.Fill`.
 """
 function fill_with end
 
-@inline function fill_with(x::T, sz::Tuple{Vararg{<:IntegerLike,N}}) where {T,N}
+@inline function fill_with(x::T, sz::Tuple{Vararg{IntegerLike,N}}) where {T,N}
     fill_with(x, map(one_to, sz))
 end
 
-@inline function fill_with(x::T, axs::Tuple{Vararg{<:AbstractUnitRange,N}}) where {T,N}
+@inline function fill_with(x::T, axs::Tuple{Vararg{AbstractUnitRange,N}}) where {T,N}
     # While `FillArrays.Fill` (mostly?) works with axes that are static unit
     # ranges, some operations that automatic differentiation requires do fail
     # on such instances of `Fill` (e.g. `reshape` from dynamic to static size).


### PR DESCRIPTION
In Julia 1.10 beta (at least) we get this warning a lot:
```
│  WARNING: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
│  You may need to write `f(x::Vararg{T})` rather than `f(x::Vararg{<:T})` or `f(x::Vararg{T}) where T` instead of `f(x::Vararg{T} where T)`.
```

[Here](https://discourse.julialang.org/t/deprecation-warnings-from-atom-with-v1-7/72400/4?u=cscherrer) Simeon Schaub suggests that to address this, "Just use Vararg{Number} instead of Vararg{<:Number}". This PR makes this small change