### PR TITLE
Invariants

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -66,6 +66,8 @@ function test_interface(μ::M) where {M}
             x = @inferred testvalue(Float64, μ)
             β = @inferred basemeasure(μ, x)
 
+            @test logdensity_def(μ, x) ≈ logdensity_rel(μ, β, x)
+
             ℓμ = @inferred logdensityof(μ, x)
             ℓβ = @inferred logdensityof(β, x)
 

--- a/test/combinators/transformedmeasure.jl
+++ b/test/combinators/transformedmeasure.jl
@@ -42,6 +42,15 @@ function test_pushfwd(f, μ, ν_ref)
         test_transport(ν_ref, ν)
 
         y = rand(ν_ref)
+        x = inverse(f)(y)
+
+        β = basemeasure(μ)
+        @test isapprox(
+            logdensity_rel(ν, pushfwd(f, β), y),
+            logdensity_rel(μ, β, x),
+            atol = 1e-10,
+        )
+
         @test isapprox(@inferred(logdensityof(ν, y)), logdensityof(ν_ref, y), atol = 1e-10)
         @test isapprox(
             @inferred(unsafe_logdensityof(ν, y)),


### PR DESCRIPTION
This PR adds two invariants:

- `logdensity_def(μ, x) ≈ logdensity_rel(μ, β, x)` (in `test_interface`)
- `logdensity_rel(pushfwd(f, μ), pushfwd(f, ν), x) == logdensity_rel(μ, ν, inverse(f)(x))` (in `test_pushfwd`)

Currently some tests are failing. I think these laws are correct, so we should examine the codebase more carefully and get this in line.